### PR TITLE
Cardholder address

### DIFF
--- a/lib/hps/entities/hps_cardholder.rb
+++ b/lib/hps/entities/hps_cardholder.rb
@@ -1,11 +1,11 @@
 module Hps
-	class HpsCardHolder
+  class HpsCardHolder
 
-		attr_accessor :first_name, :last_name, :phone, :email_address, :address
+    attr_accessor :first_name, :last_name, :phone, :email_address, :address
 
-		def initialize
-			self.address = Hps::HpsAddress.new
-		end
-
+    def initialize
+	  self.address = Hps::HpsAddress.new
 	end
+
+  end
 end

--- a/lib/hps/entities/hps_cardholder.rb
+++ b/lib/hps/entities/hps_cardholder.rb
@@ -3,5 +3,9 @@ module Hps
 
 		attr_accessor :first_name, :last_name, :phone, :email_address, :address
 
+		def initialize
+			self.address = Hps::HpsAddress.new
+		end
+
 	end
 end


### PR DESCRIPTION
Fixes NewMethodError thrown when attempting to change address. Changes made to make documentation for new [Card Holders](https://developer.heartlandpaymentsystems.com/SecureSubmit/Documentation#CardHolder) function as stated.